### PR TITLE
Continuamos con la Persistencia de Datos, recupandolos desde la BD:

### DIFF
--- a/app/src/main/java/com/example/settingsapp/SettingsModel.kt
+++ b/app/src/main/java/com/example/settingsapp/SettingsModel.kt
@@ -1,0 +1,8 @@
+package com.example.settingsapp
+
+data class SettingsModel(
+    var volume: Int,
+    var bluetooth: Boolean,
+    var darkmode: Boolean,
+    var vibration: Boolean
+)


### PR DESCRIPTION
Continuamos con la Persistencia de Datos, recupandolos desde la BD:
- Recuperamos los datos almacenados en la BD local (DataStore)
- Hacemos uso de Flow para "escuchar" los cambios de la información (configuración) que se esta almacenando.
- Creamos una data class (SettingsModel.kt) con cada uno de los campos que utliza la interfaz de la App (volume, bluetooth, darkmode y vibration), para que la función getStrings() los retorne como un Flow de tipo SettingsModel.
- Al iniciar la App, inicializamos los SwitchMaterial y RangeSlider con los valores almacenados en la BD o con los default, definidos en getStrings() si aún no hay ningun valor almacenado.